### PR TITLE
fail-safe improvements aimed at minimizing the risk of electrical or timing-related damage & Incorrect status check in mmc_initialize() due to operator precedence

### DIFF
--- a/code/busk/main.c
+++ b/code/busk/main.c
@@ -21,11 +21,11 @@ void pins_setup(void)
 	*(uint32_t*)(0x4001c000 + 4 + PIN_RST*4 + 0x2000) = 0x81;
 }
 
-// overclock setup
+// use conservative clock/voltage settings to avoid stressing hardware
 void oc_setup(void)
 {
-	vreg_set_voltage(VREG_VOLTAGE_1_30);
-	set_sys_clock_khz(200000, true);
+	vreg_set_voltage(VREG_VOLTAGE_1_10);
+	set_sys_clock_khz(125000, true);
 }
 
 void zzz() {

--- a/code/usk/glitch.c
+++ b/code/usk/glitch.c
@@ -55,8 +55,8 @@ void init_glitch_pio() {
     for (int i = PIN_CLK; i <= PIN_DAT; i++)
     {
         gpio_init(i);
-        gpio_enable_input_output(i);
-        gpio_pull_up(i);
+        gpio_set_dir(i, GPIO_IN);
+        gpio_disable_pulls(i);
     }
     gpio_init(gli_pin());
     init_gsniff_pio();

--- a/code/usk/main.c
+++ b/code/usk/main.c
@@ -21,10 +21,10 @@
 
 bool write_payload();
 
-// overclock to 300 MHz
+// use conservative clock/voltage settings to avoid stressing hardware
 void init_system() {
-    vreg_set_voltage(VREG_VOLTAGE_1_30);
-	set_sys_clock_khz(300000, true);
+    vreg_set_voltage(VREG_VOLTAGE_1_10);
+	set_sys_clock_khz(125000, true);
 }
 
 // filled within "fast check" on eMMC init
@@ -41,11 +41,13 @@ void rewrite_payload()
 
 bool safe_test_voltage(int pin, float target, float range)
 {
-    gpio_enable_input_output(pin);
+    gpio_init(pin);
+    gpio_set_dir(pin, GPIO_IN);
+    gpio_disable_pulls(pin);
     adc_gpio_init(pin);
     adc_select_input(pin - 26);
     uint16_t result = adc_read();
-    gpio_disable_input_output(pin);
+    gpio_deinit(pin);
     float voltage = result * 3.3f / (1 << 12);
     return voltage >= (target - range) && voltage <= (target + range);
 }

--- a/code/usk/payload.c
+++ b/code/usk/payload.c
@@ -425,7 +425,7 @@ bool mmc_initialize() {
         if (!simple_cmd_exec_with_ret(mmc_init_table[i], mmc_init_table[i+1], &res)) {
             return false;
         }
-        if (res & mmc_init_table[i+2] != mmc_init_table[i+3]) {
+        if ((res & mmc_init_table[i+2]) != mmc_init_table[i+3]) {
             return false;
         }
     }


### PR DESCRIPTION
Summary

Reduced the target voltage and clock frequency in two firmware images to lower electrical and thermal stress and provide a more conservative operating mode.

ADC checks were switched to input mode without pull-ups to avoid actively driving lines during measurements.

During glitch subsystem initialization, eMMC lines are configured as inputs without pull-ups to minimize active influence on sensitive 1.8V signals.

Incorrect status check in mmc_initialize() due to operator precedence

Testing

⚠️ Not tested on real hardware.
These changes are based on code review and documentation analysis only. Validation on a physical RP2040 board and the target device is required to confirm correct behavior and to rule out unintended side effects.